### PR TITLE
Do not set Xmx and Xms

### DIFF
--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -32,6 +32,7 @@ ENV PATH=/usr/share/logstash/bin:$PATH
 ADD config/pipelines.yml config/pipelines.yml
 ADD config/logstash-full.yml config/logstash.yml
 ADD config/log4j2.properties config/
+ADD config/jvm.options config/
 ADD pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 

--- a/logstash/config/jvm.options
+++ b/logstash/config/jvm.options
@@ -1,0 +1,81 @@
+## JVM configuration
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+#-Xms1g
+#-Xmx1g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## Locale
+# Set the locale language
+#-Duser.language=en
+
+# Set the locale country
+#-Duser.country=US
+
+# Set the locale variant, if any
+#-Duser.variant=
+
+## basic
+
+# set the I/O temp directory
+#-Djava.io.tmpdir=$HOME
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+#-Djna.nosys=true
+
+# Turn on JRuby invokedynamic
+-Djruby.compile.invokedynamic=true
+# Force Compilation
+-Djruby.jit.threshold=0
+# Make sure joni regexp interruptability is enabled
+-Djruby.regexp.interruptible=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof
+
+## GC logging
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${LS_GC_LOG_FILE}
+
+# Entropy source for randomness
+-Djava.security.egd=file:/dev/urandom
+
+# Copy the logging context from parent threads to children
+-Dlog4j2.isThreadContextMapInheritable=true


### PR DESCRIPTION
So we can take advantage of container limits using

* -XX:InitialRAMPercentage
* -XX:MaxRAMPercentage

Before, a 512m container would try to use 1GB as it is hardcoded in `/usr/share/logstash/config/jvm.options` and crash. A 1GB+ container would not use all the memory available

```
docker run --name logstash -m 512m -e LS_JAVA_OPTS="-XshowSettings:vm -XX:+PrintFlagsFinal -XX:MaxRAMPercentage=99 -XX:InitialRAMPercentage=99" -ti --rm logstash | grep HeapSize
   size_t InitialHeapSize                          = 1073741824                                {product} {command line}
   size_t MaxHeapSize                              = 1073741824                                {product} {command line}
```

After, we can leave the JVM to calculate the heap (1/4 of total by default)

```
docker run --name logstash -m 512m -e LS_JAVA_OPTS="-XshowSettings:vm -XX:+PrintFlagsFinal" -ti --rm logstash:csanchez | grep HeapSize
   size_t InitialHeapSize                          = 8388608                                   {product} {ergonomic}
   size_t MaxHeapSize                              = 134217728                                 {product} {ergonomic}
```

Or we can set a percentage of the memory with `-XX:MaxRAMPercentage` and `-XX:InitialRAMPercentage`

```
docker run --name logstash -m 512m -e LS_JAVA_OPTS="-XshowSettings:vm -XX:+PrintFlagsFinal -XX:MaxRAMPercentage=99 -XX:InitialRAMPercentage=99" -ti --rm logstash:csanchez | grep HeapSize
   size_t InitialHeapSize                          = 532676608                                 {product} {ergonomic}
   size_t MaxHeapSize                              = 532676608                                 {product} {ergonomic}
```
