### PR TITLE
Allow setting of Monitoring CCS and Screenshotting Sandbox via env vars

### DIFF
--- a/kibana/bin/kibana-docker
+++ b/kibana/bin/kibana-docker
@@ -116,6 +116,7 @@ kibana_vars=(
     monitoring.cluster_alerts.email_notifications.email_address
     monitoring.kibana.collection.enabled
     monitoring.kibana.collection.interval
+    monitoring.ui.ccs.enabled
     monitoring.ui.container.elasticsearch.enabled
     monitoring.ui.container.logstash.enabled
     monitoring.ui.elasticsearch.hosts
@@ -358,6 +359,7 @@ kibana_vars=(
     xpack.reporting.roles.allow
     xpack.reporting.roles.enabled
     xpack.ruleRegistry.write.enabled
+    xpack.screenshotting.browser.chromium.disableSandbox
     xpack.security.accessAgreement.message
     xpack.security.audit.appender.fileName
     xpack.security.audit.appender.layout.highlight


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/183795

Allow configuration of `monitoring.ui.ccs.enabled` and `xpack.screenshotting.browser.chromium.disableSandbox` settings via environment variables in the `kibana-docker` startup script within the official Kibana Docker Image.