### PR TITLE
Adding the Github Action to to auto-approve

### DIFF
--- a/.github/workflows/pr_auto_approval.yml
+++ b/.github/workflows/pr_auto_approval.yml
@@ -7,7 +7,8 @@ jobs:
       name: Auto-approve docker push pr
       runs-on: ubuntu-latest
       if: |
-        startsWith(github.event.pull_request.head.ref, 'docker_files_push')
+        startsWith(github.event.pull_request.head.ref, 'docker_files_push') &&
+        github.event.pull_request.user.login == 'elasticmachine'
       permissions:
         pull-requests: write
       steps:

--- a/.github/workflows/pr_auto_approval.yml
+++ b/.github/workflows/pr_auto_approval.yml
@@ -7,8 +7,7 @@ jobs:
       name: Auto-approve docker push pr
       runs-on: ubuntu-latest
       if: |
-        startsWith(github.event.pull_request.head.ref, 'docker_files_push') &&
-        github.event.pull_request.user.login == 'elasticmachine'
+        startsWith(github.event.pull_request.head.ref, 'docker_files_push')
       permissions:
         pull-requests: write
       steps:

--- a/.github/workflows/pr_auto_approval.yml
+++ b/.github/workflows/pr_auto_approval.yml
@@ -1,0 +1,14 @@
+on:
+    pull_request_target:
+      branches-ignore:
+        - 8.13
+jobs:
+    approve:
+      name: Auto-approve docker push pr
+      runs-on: ubuntu-latest
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'docker_files_push')
+      permissions:
+        pull-requests: write
+      steps:
+        - uses: hmarr/auto-approve-action@v3


### PR DESCRIPTION
Adding Github auto-approval action for that only check that PR starts with `docker_files_push` 
Tested on this branch (6.13) https://github.com/elastic/dockerfiles/pull/193, PR got automatically approved and merged.

Note: The Github action checks  only the PR branch pattern. I attempted to check user accounts, specifically `elastic-vault-github-plugin-prod` & `elasticmachine` bot, but they both lead to the GitHub action to be skipped.