### PR TITLE
Fix Github action flow

### DIFF
--- a/.github/workflows/pr_auto_approval.yml
+++ b/.github/workflows/pr_auto_approval.yml
@@ -1,27 +1,24 @@
 on:
-    pull_request:
-      types:
-        - opened
-      branches:
-        - '*'
+  pull_request:
+    types:
+      - opened
+    branches:
+      - '*'
 
 jobs:
-    approve:
-      name: Auto-approve docker push pr
-      runs-on: ubuntu-latest
-      if: |
-        startsWith(github.event.pull_request.head.ref, 'docker_files_push_') &&
-        github.event.pull_request.user.login == 'elasticmachine'
-      permissions:
-        pull-requests: write
-        contents: write
-      steps:
-      - name: Debug PR info
-        run: |
-          echo "PR Head Ref: ${{ github.event.pull_request.head.ref }}"
-          echo "PR User Login: ${{ github.event.pull_request.user.login }}"
-
-      - name: Auto Approve
-        uses: hmarr/auto-approve-action@v3
-        with:
-          github_token: ${{secrets.ELASTICMACHINE_TOKEN}}
+  approve:
+    name: Auto-approve docker push pr
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'docker_files_push_') &&
+      github.event.pull_request.user.login == 'elastic-vault-github-plugin-prod[bot]'
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+    - name: Debug PR info
+      run: |
+        echo "PR Head Ref: ${{ github.event.pull_request.head.ref }}"
+        echo "PR User Login: ${{ github.event.pull_request.user.login }}"
+    - name: Auto Approve
+      uses: hmarr/auto-approve-action@v3


### PR DESCRIPTION
This change is to update the Github action flow to use user `elastic-vault-github-plugin-prod[bot]`
Tested on https://github.com/elastic/dockerfiles/compare/8.13...test_branch
BK job created pr, Github action approved, got merged https://buildkite.com/elastic/unified-release-releasing/builds/859#01936ff9-ef93-456b-a908-ccb2be276620