### PR TITLE
Patch dockerfiles to use redhat/ubi9-minimal:latest as a base image

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -9,7 +9,7 @@
 # Extract Elasticsearch artifact
 ################################################################################
 
-FROM docker.elastic.co/ubi9/ubi-minimal:latest AS builder
+FROM redhat/ubi9-minimal:latest AS builder
 
 # Install required packages to extract the Elasticsearch distribution
 
@@ -79,7 +79,7 @@ RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elas
 # Add entrypoint
 ################################################################################
 
-FROM docker.elastic.co/ubi9/ubi-minimal:latest
+FROM redhat/ubi9-minimal:latest
 
 RUN for iter in 1 2 3 4 5 6 7 8 9 10; do \
       microdnf update --setopt=tsflags=nodocs -y && \

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -9,7 +9,7 @@
 # Build stage 0 `builder`:
 # Extract Kibana artifact
 ################################################################################
-FROM docker.elastic.co/ubi9/ubi-minimal:latest AS builder
+FROM redhat/ubi9-minimal:latest AS builder
 
 RUN microdnf install -y findutils tar gzip
 
@@ -61,7 +61,7 @@ RUN mkdir -p /usr/share/fonts/local && \
 # Copy kibana from stage 0
 # Add entrypoint
 ################################################################################
-FROM docker.elastic.co/ubi9/ubi-minimal:latest
+FROM redhat/ubi9-minimal:latest
 EXPOSE 5601
 
 RUN for iter in {1..10}; do \

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -13,7 +13,7 @@ RUN go build
 
 # Build main image
 # Minimal distributions do not ship with en language packs.
-FROM docker.elastic.co/ubi9/ubi-minimal
+FROM redhat/ubi9-minimal:latest
 
 ENV ELASTIC_CONTAINER true
 ENV PATH=/usr/share/logstash/bin:$PATH


### PR DESCRIPTION
Use redhat/ubi9-minimal:latest as a base image
