### PR TITLE
Fix 9.0.2 contexts

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux ; \
     chmod 0555 /bin/tini
 
 WORKDIR /usr/share/elasticsearch
-RUN arch="$(rpm --query --queryformat='%{ARCH}' rpm)" && curl -f --retry 10 -S -L --output /tmp/elasticsearch.tar.gz https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-9.0.2-linux-${arch}.tar.gz
+RUN arch="$(rpm --query --queryformat='%{ARCH}' rpm)" && curl -f --retry 10 -S -L --output /tmp/elasticsearch.tar.gz https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-9.0.2-linux-$arch.tar.gz
 RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1 && \
 # Configure the distribution for Docker
     sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elasticsearch-env && \

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -17,7 +17,7 @@ RUN microdnf install -y findutils tar gzip
 # build. Instead, we check the binary against the published checksum.
 RUN set -eux ; \
     tini_bin="" ; \
-    arch="$(rpm --query --queryformat='%{ARCH}' rpm)";     case "$(arch)" in \
+    arch="$(rpm --query --queryformat='%{ARCH}' rpm)";     case "${arch}" in \
         aarch64) tini_bin='tini-arm64' ;; \
         x86_64)  tini_bin='tini-amd64' ;; \
         *) echo >&2 ; echo >&2 "Unsupported architecture $arch" ; echo >&2 ; exit 1 ;; \
@@ -30,7 +30,7 @@ RUN set -eux ; \
     chmod 0555 /bin/tini
 
 WORKDIR /usr/share/elasticsearch
-RUN arch="$(rpm --query --queryformat='%{ARCH}' rpm)" && curl -f --retry 10 -S -L --output /tmp/elasticsearch.tar.gz https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-9.0.2-linux-$(arch).tar.gz
+RUN arch="$(rpm --query --queryformat='%{ARCH}' rpm)" && curl -f --retry 10 -S -L --output /tmp/elasticsearch.tar.gz https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-9.0.2-linux-${arch}.tar.gz
 RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1 && \
 # Configure the distribution for Docker
     sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elasticsearch-env && \
@@ -95,7 +95,6 @@ ENV SHELL=/bin/bash
 COPY --chmod=0555 bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN chmod g=u /etc/passwd && \
-    chmod 0555 /usr/local/bin/docker-entrypoint.sh && \
     find / -xdev -perm -4000 -exec chmod ug-s {} + && \
     chmod 0775 /usr/share/elasticsearch && \
     chown elasticsearch bin config config/jvm.options.d data logs plugins

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -17,7 +17,7 @@ RUN microdnf install -y findutils tar gzip
 # build. Instead, we check the binary against the published checksum.
 RUN set -eux ; \
     tini_bin="" ; \
-    arch="$(rpm --query --queryformat='%{ARCH}' rpm)";     case "${arch}" in \
+    arch="$(rpm --query --queryformat='%{ARCH}' rpm)";     case "$arch" in \
         aarch64) tini_bin='tini-arm64' ;; \
         x86_64)  tini_bin='tini-amd64' ;; \
         *) echo >&2 ; echo >&2 "Unsupported architecture $arch" ; echo >&2 ; exit 1 ;; \

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -14,10 +14,10 @@ FROM redhat/ubi9-minimal:latest AS builder
 RUN microdnf install -y findutils tar gzip
 
 RUN cd /tmp && \
-  arch="$(rpm --query --queryformat='%{ARCH}' rpm)"; \  && \
+  arch="$(rpm --query --queryformat='%{ARCH}' rpm)" && \
   curl -f --retry 8 -s -L \
     --output kibana.tar.gz \
-     https://artifacts.elastic.co/downloads/kibana/kibana-9.0.2-linux-$arch.tar.gz && \
+     https://artifacts.elastic.co/downloads/kibana/kibana-9.0.2-linux-${arch}.tar.gz && \
   cd -
 
 RUN mkdir /usr/share/kibana
@@ -35,21 +35,21 @@ RUN chmod -R g=u /usr/share/kibana
 # Add an init process, check the checksum to make sure it's a match
 RUN set -e ; \
     TINI_BIN="" ; \
-    arch="$(rpm --query --queryformat='%{ARCH}' rpm)"; \ 
+    arch="$(rpm --query --queryformat='%{ARCH}' rpm)"; \
     case "$arch" in \
         aarch64) \
             TINI_BIN='tini-arm64' ; \
+            TINI_CHECKSUM='07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81' ; \
             ;; \
         x86_64) \
             TINI_BIN='tini-amd64' ; \
+            TINI_CHECKSUM='93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c' ; \
             ;; \
         *) echo >&2 "Unsupported architecture $arch" ; exit 1 ;; \
     esac ; \
   TINI_VERSION='v0.19.0' ; \
   curl -f --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}" ; \
-  curl -f --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}.sha256sum" ; \
-  sha256sum -c "${TINI_BIN}.sha256sum" ; \
-  rm "${TINI_BIN}.sha256sum" ; \
+  echo "${TINI_CHECKSUM} ${TINI_BIN}" | sha256sum -c - ; \
   mv "${TINI_BIN}" /bin/tini ; \
   chmod +x /bin/tini
 RUN mkdir -p /usr/share/fonts/local && \

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -37,7 +37,7 @@ RUN groupadd --gid 1000 logstash && \
   curl -f -Lo logstash.tar.gz "https://artifacts.elastic.co/downloads/logstash/logstash-9.0.2-linux-${arch}.tar.gz" && \
   tar -zxf logstash.tar.gz -C /usr/share && \
   rm logstash.tar.gz && \
-  mv /usr/share/logstash-9.0.1 /usr/share/logstash && \
+  mv /usr/share/logstash-9.0.2 /usr/share/logstash && \
   chown -R logstash:root /usr/share/logstash && \
   chmod -R g=u /usr/share/logstash && \
   mkdir /licenses && \

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -20,17 +20,11 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 WORKDIR /usr/share
 
 # Install packages
-RUN for iter in {1..10}; do \
-  microdnf update -y && \
+RUN \
   microdnf install -y procps findutils tar gzip && \
   microdnf install -y openssl && \
   microdnf install -y which shadow-utils && \
-  microdnf clean all && \
-  exit_code=0 && break || \
-  exit_code=$? && echo "packaging error: retry $iter in 10s" && \
-  microdnf clean all && sleep 10; \
-  done; \
-  (exit $exit_code)
+  microdnf clean all
 
 # Provide a non-root user to run the process
 # Add Logstash itself and set permissions
@@ -39,9 +33,11 @@ RUN groupadd --gid 1000 logstash && \
   --home "/usr/share/logstash" \
   --no-create-home \
   logstash && \
-  curl -Lo - https://artifacts.elastic.co/downloads/logstash/logstash-9.0.2-linux-x86_64.tar.gz | \
-  tar zxf - -C /usr/share && \
-  mv /usr/share/logstash-9.0.2 /usr/share/logstash && \
+  arch="$(rpm --query --queryformat='%{ARCH}' rpm)" && \
+  curl -f -Lo logstash.tar.gz "https://artifacts.elastic.co/downloads/logstash/logstash-9.0.2-linux-${arch}.tar.gz" && \
+  tar -zxf logstash.tar.gz -C /usr/share && \
+  rm logstash.tar.gz && \
+  mv /usr/share/logstash-9.0.1 /usr/share/logstash && \
   chown -R logstash:root /usr/share/logstash && \
   chmod -R g=u /usr/share/logstash && \
   mkdir /licenses && \


### PR DESCRIPTION
We made several manual updates for 9.0.1 but the changes have not made it to the product generators in time for 9.0.2.

This re-adds the manual updates.

Fixes issues in https://github.com/docker-library/official-images/pull/19184

Diff comparing 9.0.1 and revised from this pr 9.0.2: https://github.com/elastic/dockerfiles/compare/c1767391264142d319c5aebbc7b44ff935ecb40d...jbudz:fix-contexts-9.0.2