### PR TITLE
upgrade logstash 8.18.3 to ubuntu 24.04

### DIFF
--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -2,7 +2,7 @@
 
 
                                         
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN for iter in {1..10}; do \
       export DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
this is a manual edit to allow 8.18.3 to be published

Logstash 8.18.4 will come with ubuntu 24.04 already, requiring no further manual editing.