### PR TITLE
[8.19] Fix Kibana build

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -15,6 +15,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN cd /tmp && \
   arch="$(dpkg --print-architecture)" && \
+  case "$arch" in \
+    amd64) arch='x86_64' ;; \
+    arm64) arch='aarch64' ;; \
+    *) echo >&2 "Unsupported architecture $arch" ; exit 1 ;; \
+  esac && \
   curl -f --retry 8 -s -L \
     --output kibana.tar.gz \
      https://artifacts.elastic.co/downloads/kibana/kibana-8.19.0-linux-${arch}.tar.gz && \


### PR DESCRIPTION
Fixes an issue where the architecture used to download kibana.tar.gz is in the wrong format.  We missed this during testing due to local artifacts being used while the released artifacts were pending.

Related to https://github.com/docker-library/official-images/pull/19558

cc @navyau09 