### PR TITLE
feat(kibana): Add support for I18N_LOCALE environment variable

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -86,6 +86,7 @@ WORKDIR /usr/share/kibana
 RUN ln -s /usr/share/kibana /opt/kibana
 
 ENV ELASTIC_CONTAINER true
+ENV I18N_LOCALE "en"
 ENV PATH=/usr/share/kibana/bin:$PATH
 
 # Set some Kibana configuration defaults.

--- a/kibana/bin/kibana-docker
+++ b/kibana/bin/kibana-docker
@@ -456,6 +456,10 @@ done
 # Files created at run-time should be group-writable, for Openshift's sake.
 umask 0002
 
+if [[ -n "$I18N_LOCALE" ]]; then
+  echo "i18n.locale: $I18N_LOCALE" >> /usr/share/kibana/config/kibana.yml
+fi
+
 # The virtual file /proc/self/cgroup should list the current cgroup
 # membership. For each hierarchy, you can follow the cgroup path from
 # this file to the cgroup filesystem (usually /sys/fs/cgroup/) and


### PR DESCRIPTION
### Summary

This pull request introduces the ability to configure the Kibana UI language directly via an `I18N_LOCALE` environment variable.  This aligns with how other core settings (like `ELASTICSEARCH_HOSTS`) are configured in the Docker image, providing a more convenient setup for international users.

### The Problem

Currently, to change the Kibana display language in a Docker environment, users must create a custom `kibana. yml` file, mount it into the container, and ensure all other necessary configurations are included.  This process can be cumbersome, especially in automated or restricted environments where file mounting is not straightforward.

### The Solution

This PR modifies the `kibana-docker` entrypoint script to:
1.   Check for the presence of a new environment variable: `I18N_LOCALE`.
2.   If the variable is set, it injects the corresponding `i18n. locale` key and value into the `/usr/share/kibana/config/kibana. yml` file before Kibana starts.

This allows users to simply add `-e I18N_LOCALE="zh-CN"` (or any other locale) to their `docker run` or `docker-compose. yml` file to set the language, without needing to manage custom configuration files.

---

### How to Test This Change

1.   **Clone the branch and navigate to the Kibana directory:**
```bash
cd kibana
```

2.   **Build the Docker image locally:**
```bash
docker build -t kibana-i18n-test .
```

3.   **Run a container with the new environment variable:**
```bash
docker run -d --rm --name test-kibana-zh \
-e I18N_LOCALE="zh-CN" \
-e ELASTICSEARCH_HOSTS="http://some-es:9200" \
kibana-i18n-test
```