### PR TITLE
[9.1.3] Update Go base image version to 1.25 to build Logstash's env2yaml

### DIFF
--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -2,7 +2,7 @@
   
           
 # Build env2yaml
-FROM golang:1.23 AS builder-env2yaml
+FROM golang:1.25 AS builder-env2yaml
 
 COPY env2yaml/env2yaml.go env2yaml/go.mod env2yaml/go.sum /tmp/go/src/env2yaml/
 


### PR DESCRIPTION
retrofit elastic/logstash#18083 to 9.1.3 to unblock docker-library/official-images#19773