### PR TITLE
Migration: reassign team ownership to @elastic/artifact-management

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @elastic/release-eng
+*   @elastic/artifact-management


### PR DESCRIPTION
Part of the EngProd GitHub team migration (parent: [#2148](https://github.com/elastic/platform-engineering-productivity/issues/2148), this touchpoint: [#2426](https://github.com/elastic/platform-engineering-productivity/issues/2426)).

**⚠️ DO NOT MERGE** until migration day. PRs are merged in batches grouped by new team owner so the [Terrazzo](https://github.com/elastic/terrazzo) wild plan for each batch can be reviewed and approved independently.


### Files changed

- `CODEOWNERS` (1 line)

---

Generated by `scripts/github-team-migration/open_repo_prs.py`.