### PR TITLE
chore: tune stale PR workflow (14-day threshold, exempt drafts)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,14 +13,15 @@ jobs:
 
     steps:
       - name: Check for stale PRs
-        uses: actions/stale@v10
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: -1  # Disables stale check for issues
           days-before-issue-close: -1  # Disables closing for issues
-          days-before-pr-stale: 7
+          days-before-pr-stale: 14
           days-before-pr-close: 7
+          exempt-draft-pr: true
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This PR looks inactive. It will be closed in 7 days if
-            there are no further updates.
+            This PR has had no activity for 14 days and is being marked stale.
+            It will be closed in 7 days if there are no further updates.


### PR DESCRIPTION
## Summary
- Increase `days-before-pr-stale` from 7 to 14 days
- Add `exempt-draft-pr: true` so draft PRs are not marked stale or auto-closed
- Pin `actions/stale` to v10.3.0 (`eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899`)
- Clarify `stale-pr-message` (marked stale after 14 days; closed 7 days later if still inactive)

Part of elastic/platform-engineering-productivity#2825.
